### PR TITLE
feat(core): implement NDIter for multi-operand broadcasting (Resolves #35)

### DIFF
--- a/rust-numpy/src/array.rs
+++ b/rust-numpy/src/array.rs
@@ -85,8 +85,8 @@ impl<T> Array<T> {
     }
 
     /// Get iterator over array elements
-    pub fn iter(&self) -> std::slice::Iter<'_, T> {
-        self.data.as_slice().iter()
+    pub fn iter(&self) -> crate::iterator::ArrayIter<'_, T> {
+        crate::iterator::ArrayIter::new(self)
     }
     ///
     /// Note: Returns a Vec by copying the array data.

--- a/rust-numpy/src/iterator.rs
+++ b/rust-numpy/src/iterator.rs
@@ -1,4 +1,8 @@
 use crate::array::Array;
+use crate::broadcasting::compute_broadcasted_strides;
+use crate::error::Result;
+use crate::strides::compute_broadcast_shape;
+use crate::ufunc::ArrayView;
 
 /// Iterator over array elements
 pub struct ArrayIter<'a, T> {
@@ -29,10 +33,10 @@ impl<'a, T> Iterator for ArrayIter<'a, T> {
             return None;
         }
 
-        // Get element at current offset
-        // We trust our offset calculation is correct and within bounds of the storage
-        // relative to array.offset
-        let item = self.array.get(self.current_offset as usize);
+        // Get element at current physical offset
+        let physical_idx = (self.array.offset as isize + self.current_offset) as usize;
+        // Use direct data access via MemoryManager (which handles UnsafeCell)
+        let item = self.array.data.get(physical_idx);
 
         // Advance counters
         self.remaining -= 1;
@@ -68,3 +72,107 @@ impl<'a, T> Iterator for ArrayIter<'a, T> {
 }
 
 impl<'a, T> ExactSizeIterator for ArrayIter<'a, T> {}
+
+/// Multi-operand N-dimensional iterator for broadcasting support
+pub struct NDIter<'a> {
+    #[allow(dead_code)]
+    operands: Vec<&'a dyn ArrayView>,
+    shape: Vec<usize>,
+    operand_strides: Vec<Vec<isize>>,
+    indices: Vec<usize>,
+    current_offsets: Vec<isize>,
+    remaining: usize,
+    started: bool,
+}
+
+impl<'a> NDIter<'a> {
+    pub fn new(operands: Vec<&'a dyn ArrayView>) -> Result<Self> {
+        if operands.is_empty() {
+            return Err(crate::error::NumPyError::invalid_operation(
+                "NDIter requires at least one operand",
+            ));
+        }
+
+        // Compute common broadcast shape
+        let mut broadcast_shape = operands[0].shape().to_vec();
+        for op in operands.iter().skip(1) {
+            broadcast_shape = compute_broadcast_shape(&broadcast_shape, op.shape());
+        }
+
+        let size: usize = broadcast_shape.iter().product();
+        let ndim = broadcast_shape.len();
+
+        // Compute broadcasted strides for each operand
+        let mut operand_strides = Vec::with_capacity(operands.len());
+        let mut initial_offsets = Vec::with_capacity(operands.len());
+        for op in &operands {
+            let strides = compute_broadcasted_strides(op.shape(), op.strides(), &broadcast_shape);
+            operand_strides.push(strides);
+            initial_offsets.push(op.offset() as isize);
+        }
+
+        Ok(Self {
+            operands,
+            shape: broadcast_shape,
+            operand_strides,
+            indices: vec![0; ndim],
+            current_offsets: initial_offsets,
+            remaining: size,
+            started: false,
+        })
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    pub fn size(&self) -> usize {
+        self.remaining
+    }
+}
+
+impl<'a> Iterator for NDIter<'a> {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+
+        if !self.started {
+            self.started = true;
+        } else {
+            // Advance indices and offsets
+            let ndim = self.shape.len();
+            for i in (0..ndim).rev() {
+                self.indices[i] += 1;
+
+                // Update offsets for each operand
+                for (op_idx, op_strides) in self.operand_strides.iter().enumerate() {
+                    self.current_offsets[op_idx] += op_strides[i];
+                }
+
+                if self.indices[i] < self.shape[i] {
+                    break;
+                }
+
+                // Carry over
+                self.indices[i] = 0;
+                for (op_idx, op_strides) in self.operand_strides.iter().enumerate() {
+                    self.current_offsets[op_idx] -= op_strides[i] * (self.shape[i] as isize);
+                }
+            }
+        }
+
+        self.remaining -= 1;
+
+        // Return current offsets as usize
+        Some(self.current_offsets.iter().map(|&o| o as usize).collect())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<'a> ExactSizeIterator for NDIter<'a> {}

--- a/rust-numpy/src/ufunc.rs
+++ b/rust-numpy/src/ufunc.rs
@@ -13,6 +13,10 @@ impl<T: 'static> ArrayView for Array<T> {
         &self.shape
     }
 
+    fn offset(&self) -> usize {
+        self.offset
+    }
+
     fn strides(&self) -> &[isize] {
         self.strides()
     }
@@ -111,6 +115,9 @@ pub trait ArrayView {
 
     /// Get total size
     fn size(&self) -> usize;
+
+    /// Get base offset
+    fn offset(&self) -> usize;
 
     /// Get number of dimensions
     fn ndim(&self) -> usize;

--- a/rust-numpy/tests/issue_35_iterator.rs
+++ b/rust-numpy/tests/issue_35_iterator.rs
@@ -1,0 +1,58 @@
+use numpy::array::Array;
+use numpy::slicing::{MultiSlice, Slice};
+
+#[test]
+fn test_iter_strided() {
+    // Array: [0, 1, 2, 3, 4]
+    let a = Array::from_vec(vec![0, 1, 2, 3, 4]);
+
+    // Slice: [::2] -> [0, 2, 4]
+    // Manual construction of MultiSlice since s! macro might be flaky or I don't know the syntax
+    // MultiSlice { slices: vec![Slice::Step(2)] }
+
+    let mut slices = Vec::new();
+    slices.push(Slice::Step(2));
+    let multi_slice = MultiSlice::new(slices);
+
+    let sliced = a.slice(&multi_slice).unwrap();
+
+    // Check shape and strides to be sure
+    // Shape should be [3] (0, 2, 4)
+    // Strides should be [2]
+    assert_eq!(sliced.shape(), &[3]);
+    assert_eq!(sliced.strides(), &[2]);
+
+    // Iterate
+    let gathered: Vec<i32> = sliced.iter().cloned().collect();
+
+    assert_eq!(gathered, vec![0, 2, 4]);
+}
+
+#[test]
+fn test_iter_multi_dim() {
+    // 2D Array
+    // [[0, 1, 2],
+    //  [3, 4, 5]]
+    let a = Array::from_vec(vec![0, 1, 2, 3, 4, 5])
+        .reshape(&[2, 3])
+        .unwrap();
+
+    // Slice: rows 0..2, cols ::2  -> [[0, 2], [3, 5]]
+    // Strides for original: [3, 1]
+    // Strides for slice: [3, 2]
+
+    let mut slices = Vec::new();
+    slices.push(Slice::Full); // dim 0
+    slices.push(Slice::Step(2)); // dim 1
+    let multi_slice = MultiSlice::new(slices);
+
+    let sliced = a.slice(&multi_slice).unwrap();
+
+    assert_eq!(sliced.shape(), &[2, 2]);
+    assert_eq!(sliced.strides(), &[3, 2]);
+
+    let gathered: Vec<i32> = sliced.iter().cloned().collect();
+
+    // Expected order: 0, 2, 3, 5
+    assert_eq!(gathered, vec![0, 2, 3, 5]);
+}

--- a/rust-numpy/tests/issue_35_verification.rs
+++ b/rust-numpy/tests/issue_35_verification.rs
@@ -1,0 +1,67 @@
+use numpy::array::Array;
+use numpy::iterator::NDIter;
+
+#[test]
+fn test_nditer_broadcasting_2d() {
+    // A: (2, 1) -> [[0], [1]]
+    let a = Array::from_vec(vec![0, 1]).reshape(&[2, 1]).unwrap();
+    // B: (1, 3) -> [[10, 20, 30]]
+    let b = Array::from_vec(vec![10, 20, 30]).reshape(&[1, 3]).unwrap();
+
+    // Broadcasted shape: (2, 3)
+    // Values:
+    // [[10, 20, 30],
+    //  [11, 21, 31]]  (if we were adding them)
+
+    let mut iter = NDIter::new(vec![&a, &b]).unwrap();
+    assert_eq!(iter.shape(), &[2, 3]);
+
+    let mut offsets = Vec::new();
+    while let Some(current_offsets) = iter.next() {
+        offsets.push(current_offsets);
+    }
+
+    // Expected offsets:
+    // (0,0): A[0,0] offset=0, B[0,0] offset=0
+    // (0,1): A[0,0] offset=0, B[0,1] offset=1
+    // (0,2): A[0,0] offset=0, B[0,2] offset=2
+    // (1,0): A[1,0] offset=1, B[0,0] offset=0
+    // (1,1): A[1,0] offset=1, B[0,1] offset=1
+    // (1,2): A[1,0] offset=1, B[0,2] offset=2
+
+    let expected = vec![
+        vec![0, 0],
+        vec![0, 1],
+        vec![0, 2],
+        vec![1, 0],
+        vec![1, 1],
+        vec![1, 2],
+    ];
+
+    assert_eq!(offsets, expected);
+}
+
+#[test]
+fn test_nditer_3d_complex() {
+    // A: (2, 1, 1)
+    let a = Array::from_vec(vec![100, 200]).reshape(&[2, 1, 1]).unwrap();
+    // B: (1, 2, 1)
+    let b = Array::from_vec(vec![10, 20]).reshape(&[1, 2, 1]).unwrap();
+    // C: (1, 1, 2)
+    let c = Array::from_vec(vec![1, 2]).reshape(&[1, 1, 2]).unwrap();
+
+    let iter = NDIter::new(vec![&a, &b, &c]).unwrap();
+    let res: Vec<Vec<usize>> = iter.collect();
+
+    assert_eq!(res.len(), 8);
+    // Should be all combinations
+    // (0,0,0), (0,0,1), (0,1,0), (0,1,1), (1,0,0), (1,0,1), (1,1,0), (1,1,1)
+    // A offsets: 0, 0, 0, 0, 1, 1, 1, 1
+    // B offsets: 0, 0, 1, 1, 0, 0, 1, 1
+    // C offsets: 0, 1, 0, 1, 0, 1, 0, 1
+
+    assert_eq!(res[0], vec![0, 0, 0]);
+    assert_eq!(res[1], vec![0, 0, 1]);
+    assert_eq!(res[4], vec![1, 0, 0]);
+    assert_eq!(res[7], vec![1, 1, 1]);
+}


### PR DESCRIPTION
This PR implements a correct baseline N-D iterator (`NDIter`) that yields per-operand element offsets for broadcasted layouts. It also adds the `offset()` method to `ArrayView` to correctly handle array slicing offsets during iteration.