### PR TITLE
[rust-numpy] Advanced array methods

### DIFF
--- a/rust-numpy/src/lib.rs
+++ b/rust-numpy/src/lib.rs
@@ -63,6 +63,7 @@ pub mod window;
 
 // Re-export key types for convenience
 pub use array::Array;
+pub use array_manipulation::exports::*;
 pub use bitwise::*;
 pub use dtype::{Casting, Dtype, DtypeKind};
 pub use error::{NumPyError, Result};

--- a/rust-numpy/src/linalg/eigen.rs
+++ b/rust-numpy/src/linalg/eigen.rs
@@ -1,5 +1,6 @@
 use crate::array::Array;
 use crate::error::NumPyError;
+use crate::linalg::LinalgScalar;
 use num_complex::{Complex, Complex64};
 use num_traits::{One, Zero};
 

--- a/rust-numpy/tests/conformance_tests.rs
+++ b/rust-numpy/tests/conformance_tests.rs
@@ -158,7 +158,7 @@ mod tests {
             let arr = Array::from_vec(vec![1.0f64, 2.0f64]);
             let result = numpy::advanced_broadcast::repeat(&arr, 2, None).unwrap();
             assert_eq!(result.shape(), vec![4]);
-            assert_eq!(result.to_vec(), vec![1.0, 2.0, 1.0, 2.0]);
+            assert_eq!(result.to_vec(), vec![1.0, 1.0, 2.0, 2.0]);
         }
     );
 


### PR DESCRIPTION
## Summary
- expose repeat/tile wrappers in array manipulation exports
- normalize squeeze axes handling and expose moveaxis/rollaxis/swapaxes
- import LinalgScalar for eigen from_real usage
- update conformance expectations for repeat

## Testing
-  (fails: missing set_ops functions in conformance_tests)\n\nResolves #49