### PR TITLE
feat(rust-numpy): Implement linspace, logspace, geomspace, and full

### DIFF
--- a/rust-numpy/src/array_creation.rs
+++ b/rust-numpy/src/array_creation.rs
@@ -97,6 +97,141 @@ where
     Ok(Array::from_vec(clipped))
 }
 
+/// Create evenly spaced numbers over a specified interval (similar to np.linspace).
+///
+/// # Arguments
+/// - `start`: Start value (inclusive)
+/// - `stop`: Stop value
+/// - `num`: Number of samples to generate (default 50)
+/// - `endpoint`: If true, stop is the last sample. If false, it is not included (default true)
+///
+/// # Returns
+/// 1D array of evenly spaced f32 values
+///
+/// # Examples
+/// ```ignore
+/// let arr = linspace(0.0, 10.0, Some(5), Some(true)).unwrap();
+/// // Result: [0.0, 2.5, 5.0, 7.5, 10.0]
+/// ```
+pub fn linspace(
+    start: f32,
+    stop: f32,
+    num: Option<usize>,
+    endpoint: Option<bool>,
+) -> Result<Array<f32>> {
+    let num_val = num.unwrap_or(50);
+
+    if num_val == 0 {
+        return Ok(Array::from_vec(vec![]));
+    }
+
+    if num_val == 1 {
+        return Ok(Array::from_vec(vec![start]));
+    }
+
+    let endpoint_val = endpoint.unwrap_or(true);
+    let div = if endpoint_val {
+        (num_val - 1) as f32
+    } else {
+        num_val as f32
+    };
+
+    let step = (stop - start) / div;
+    let data: Vec<f32> = (0..num_val).map(|i| start + (i as f32) * step).collect();
+
+    Ok(Array::from_vec(data))
+}
+
+/// Create evenly spaced numbers on a log scale (similar to np.logspace).
+///
+/// # Arguments
+/// - `start`: Start value as power of base (base^start)
+/// - `stop`: Stop value as power of base (base^stop)
+/// - `num`: Number of samples to generate (default 50)
+/// - `endpoint`: If true, stop is the last sample. If false, it is not included (default true)
+/// - `base`: The base of the log space (default 10.0)
+///
+/// # Returns
+/// 1D array of f32 values evenly spaced on a log scale
+///
+/// # Examples
+/// ```ignore
+/// let arr = logspace(1.0, 3.0, Some(3), Some(true), Some(10.0)).unwrap();
+/// // Result: [10.0, 100.0, 1000.0]
+/// ```
+pub fn logspace(
+    start: f32,
+    stop: f32,
+    num: Option<usize>,
+    endpoint: Option<bool>,
+    base: Option<f32>,
+) -> Result<Array<f32>> {
+    let base_val = base.unwrap_or(10.0);
+    let lin = linspace(start, stop, num, endpoint)?;
+    let logged: Vec<f32> = lin.data().iter().map(|&x| base_val.powf(x)).collect();
+
+    Ok(Array::from_vec(logged))
+}
+
+/// Create evenly spaced numbers on a geometric progression (similar to np.geomspace).
+///
+/// # Arguments
+/// - `start`: Start value (must be non-zero)
+/// - `stop`: Stop value
+/// - `num`: Number of samples to generate (default 50)
+/// - `endpoint`: If true, stop is the last sample. If false, it is not included (default true)
+///
+/// # Returns
+/// 1D array of f32 values on a geometric progression
+///
+/// # Examples
+/// ```ignore
+/// let arr = geomspace(1.0, 1000.0, Some(4), Some(true)).unwrap();
+/// // Result: [1.0, 10.0, 100.0, 1000.0]
+/// ```
+pub fn geomspace(
+    start: f32,
+    stop: f32,
+    num: Option<usize>,
+    endpoint: Option<bool>,
+) -> Result<Array<f32>> {
+    if start == 0.0 || stop == 0.0 {
+        return Err(NumPyError::invalid_value(
+            "geomspace: start and stop must not be zero",
+        ));
+    }
+
+    let start_log = start.ln();
+    let stop_log = stop.ln();
+    let lin = linspace(start_log, stop_log, num, endpoint)?;
+    let geo: Vec<f32> = lin.data().iter().map(|&x| x.exp()).collect();
+
+    Ok(Array::from_vec(geo))
+}
+
+/// Create a new array of given shape, filled with a fill value (similar to np.full).
+///
+/// # Arguments
+/// - `shape`: Shape of the new array
+/// - `fill_value`: Fill value
+///
+/// # Returns
+/// Array filled with fill_value
+///
+/// # Examples
+/// ```ignore
+/// let arr = full(&[2, 3], 5.0).unwrap();
+/// // Result: [[5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]
+/// ```
+pub fn full<T>(shape: &[usize], fill_value: T) -> Result<Array<T>>
+where
+    T: Clone + Default + 'static,
+{
+    let size: usize = shape.iter().product();
+    let data: Vec<T> = (0..size).map(|_| fill_value.clone()).collect();
+    Ok(Array::from_data(data, shape.to_vec()))
+}
+
 /// Find minimum value in an array (similar to np.min).
 ///
 /// # Arguments
@@ -269,5 +404,105 @@ mod tests {
         assert!(v0.is_infinite() && v0 < 0.0);
         assert!(v1.is_infinite() && v1 < 0.0);
         assert!((data[2] - 0.0f32.ln()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_linspace_basic() {
+        let arr = linspace(0.0, 10.0, Some(5), Some(true)).unwrap();
+        assert_eq!(arr.shape(), &[5]);
+        let data = arr.data();
+        assert!((data[0] - 0.0).abs() < 1e-6);
+        assert!((data[1] - 2.5).abs() < 1e-6);
+        assert!((data[2] - 5.0).abs() < 1e-6);
+        assert!((data[3] - 7.5).abs() < 1e-6);
+        assert!((data[4] - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_linspace_no_endpoint() {
+        let arr = linspace(0.0, 10.0, Some(5), Some(false)).unwrap();
+        assert_eq!(arr.shape(), &[5]);
+        let data = arr.data();
+        assert!((data[0] - 0.0).abs() < 1e-6);
+        assert!((data[4] - 8.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_linspace_default_num() {
+        let arr = linspace(0.0, 10.0, None, Some(true)).unwrap();
+        assert_eq!(arr.shape(), &[50]);
+    }
+
+    #[test]
+    fn test_linspace_single_value() {
+        let arr = linspace(5.0, 10.0, Some(1), Some(true)).unwrap();
+        assert_eq!(arr.shape(), &[1]);
+        assert_eq!(arr.data()[0], 5.0);
+    }
+
+    #[test]
+    fn test_logspace_basic() {
+        let arr = logspace(0.0, 3.0, Some(4), Some(true), Some(10.0)).unwrap();
+        assert_eq!(arr.shape(), &[4]);
+        let data = arr.data();
+        assert!((data[0] - 1.0).abs() < 1e-6);
+        assert!((data[1] - 10.0).abs() < 1e-6);
+        assert!((data[2] - 100.0).abs() < 1e-6);
+        assert!((data[3] - 1000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_logspace_default_base() {
+        let arr = logspace(0.0, 2.0, Some(3), Some(true), None).unwrap();
+        assert_eq!(arr.shape(), &[3]);
+        let data = arr.data();
+        assert!((data[0] - 1.0).abs() < 1e-6);
+        assert!((data[1] - 10.0).abs() < 1e-6);
+        assert!((data[2] - 100.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_geomspace_basic() {
+        let arr = geomspace(1.0, 1000.0, Some(4), Some(true)).unwrap();
+        assert_eq!(arr.shape(), &[4]);
+        let data = arr.data();
+        assert!((data[0] - 1.0).abs() < 1e-4);
+        assert!((data[1] - 10.0).abs() < 1e-3);
+        assert!((data[2] - 100.0).abs() < 1e-2); // Allow more tolerance for larger values
+        assert!((data[3] - 1000.0).abs() < 1e-1);
+    }
+
+    #[test]
+    fn test_geomspace_zero_error() {
+        let result = geomspace(0.0, 100.0, Some(5), Some(true));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_full_1d() {
+        let arr = full(&[5], 7.0_f32).unwrap();
+        assert_eq!(arr.shape(), &[5]);
+        let data = arr.data();
+        for &v in data.iter() {
+            assert_eq!(v, 7.0);
+        }
+    }
+
+    #[test]
+    fn test_full_2d() {
+        let arr = full(&[2, 3], 5.0_f32).unwrap();
+        assert_eq!(arr.shape(), &[2, 3]);
+        assert_eq!(arr.size(), 6);
+        let data = arr.data();
+        for &v in data.iter() {
+            assert_eq!(v, 5.0);
+        }
+    }
+
+    #[test]
+    fn test_full_empty() {
+        let arr = full(&[0], 5.0_f32).unwrap();
+        assert_eq!(arr.shape(), &[0]);
+        assert_eq!(arr.size(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Implements `linspace` for creating evenly spaced numbers over a specified interval
- Implements `logspace` for creating numbers evenly spaced on a log scale
- Implements `geomspace` for creating numbers on a geometric progression
- Implements `full` for creating arrays filled with a fill value

## Test plan
- [x] All new tests pass (linspace, logspace, geomspace, full)
- [x] Code formatted with cargo fmt
- [x] No new clippy warnings in modified code

🤖 Generated with [Claude Code](https://claude.com/claude-code)