### PR TITLE
feat(set_ops): implement isin function (Resolves #179)

### DIFF
--- a/rust-numpy/src/set_ops.rs
+++ b/rust-numpy/src/set_ops.rs
@@ -434,6 +434,58 @@ where
     Ok(Array::from_vec(result))
 }
 
+/// Calculates element in test_elements, broadcasting over element only.
+///
+/// Returns a boolean array of the same shape as `element` that is True where an element
+/// of `element` is in `test_elements` and False otherwise.
+///
+/// # Arguments
+///
+/// * `element` - Input array
+/// * `test_elements` - The values against which to test each value of `element`
+/// * `assume_unique` - If True, the input arrays are both assumed to be unique
+/// * `invert` - If True, the values in the returned array are inverted
+///
+/// # Examples
+///
+/// ```rust
+/// use rust_numpy::set_ops::isin;
+/// let element = array2![[1, 2], [3, 4]];
+/// let test_elements = array![1, 3];
+/// let result = isin(&element, &test_elements, false, false).unwrap();
+/// // result == [[true, false], [true, false]]
+/// ```
+pub fn isin<T>(
+    element: &Array<T>,
+    test_elements: &Array<T>,
+    assume_unique: bool,
+    invert: bool,
+) -> Result<Array<bool>>
+where
+    T: SetElement + Clone + Default + 'static,
+{
+    // Flatten element array to 1D
+    let flattened_element = Array::from_vec(element.to_vec());
+
+    // Flatten test_elements array to 1D
+    let flattened_test = Array::from_vec(test_elements.to_vec());
+
+    // Call in1d
+    let mut result = in1d(&flattened_element, &flattened_test, assume_unique)?;
+
+    // Handle invert
+    if invert {
+        let mut inverted_data = Vec::with_capacity(result.size());
+        for i in 0..result.size() {
+            inverted_data.push(!result.get_linear(i).unwrap());
+        }
+        result = Array::from_vec(inverted_data);
+    }
+
+    // Reshape back to original shape
+    result.reshape(element.shape())
+}
+
 /// Advanced set operations for multi-dimensional arrays
 pub struct SetOps;
 
@@ -457,5 +509,5 @@ impl SetOps {
 }
 
 pub mod exports {
-    pub use super::{in1d, unique, SetElement, SetOps, UniqueResult};
+    pub use super::{in1d, isin, unique, SetElement, SetOps, UniqueResult};
 }

--- a/rust-numpy/tests/set_ops_tests.rs
+++ b/rust-numpy/tests/set_ops_tests.rs
@@ -1,5 +1,5 @@
 use numpy::array::Array;
-use numpy::set_ops::in1d;
+use numpy::set_ops::{in1d, isin};
 
 #[test]
 fn test_in1d_basic() {
@@ -31,4 +31,21 @@ fn test_in1d_strings() {
     let ar2 = Array::from_vec(vec!["a".to_string(), "c".to_string()]);
     let result = in1d(&ar1, &ar2, false).unwrap();
     assert_eq!(result.to_vec(), vec![true, false, true]);
+}
+
+#[test]
+fn test_isin_basic() {
+    let ar1 = Array::from_vec(vec![0, 1, 2, 5, 0]);
+    let ar2 = Array::from_vec(vec![0, 2]);
+    let result = isin(&ar1, &ar2, false, false).unwrap();
+    assert_eq!(result.to_vec(), vec![true, false, true, false, true]);
+}
+
+#[test]
+fn test_isin_2d() {
+    let ar1 = Array::from_shape_vec(vec![2, 3], vec![0, 1, 2, 3, 4, 5]);
+    let ar2 = Array::from_vec(vec![0, 2, 4]);
+    let result = isin(&ar1, &ar2, false, false).unwrap();
+    assert_eq!(result.shape(), &[2, 3]);
+    assert_eq!(result.to_vec(), vec![true, false, true, false, true, false]);
 }


### PR DESCRIPTION
Implemented `isin` by flattening inputs, delegating to `in1d`, and reshaping the result. Added comprehensive tests.