### PR TITLE
Implement basic set operations (Issue #180)

### DIFF
--- a/rust-numpy/src/dtype.rs
+++ b/rust-numpy/src/dtype.rs
@@ -21,6 +21,8 @@ pub enum Casting {
     Unsafe,
     /// Allow any cast (legacy name for Unsafe)
     Equiv,
+    /// Identical types only
+    No,
 }
 
 /// Comprehensive dtype system matching NumPy's type system
@@ -420,6 +422,7 @@ impl Dtype {
             Casting::Unsafe | Casting::Equiv => true,
             Casting::SameKind => self.can_cast_same_kind(to),
             Casting::Safe => self.can_cast_safe(to),
+            Casting::No => false,
         }
     }
 

--- a/rust-numpy/src/lib.rs
+++ b/rust-numpy/src/lib.rs
@@ -72,6 +72,7 @@ pub use dtype::{Casting, Dtype, DtypeKind};
 pub use error::{NumPyError, Result};
 pub use fft::{fft_with_params, hilbert_with_params, ifft, irfft2, irfftn, rfft2, rfftn};
 pub use linalg::norm;
+pub use set_ops::exports::*;
 pub use statistics::{std, var};
 pub use type_promotion::promote_types;
 pub use ufunc_ops::UfuncEngine;

--- a/rust-numpy/tests/set_ops_tests.rs
+++ b/rust-numpy/tests/set_ops_tests.rs
@@ -1,5 +1,5 @@
 use numpy::array::Array;
-use numpy::set_ops::{in1d, isin};
+use numpy::set_ops::{in1d, intersect1d, isin, setdiff1d, setxor1d, union1d};
 
 #[test]
 fn test_in1d_basic() {
@@ -48,4 +48,40 @@ fn test_isin_2d() {
     let result = isin(&ar1, &ar2, false, false).unwrap();
     assert_eq!(result.shape(), &[2, 3]);
     assert_eq!(result.to_vec(), vec![true, false, true, false, true, false]);
+}
+
+#[test]
+fn test_intersect1d() {
+    let ar1 = Array::from_vec(vec![1, 3, 4, 3]);
+    let ar2 = Array::from_vec(vec![3, 1, 2, 1]);
+    let result = intersect1d(&ar1, &ar2, false, false).unwrap();
+    // Unique common elements, sorted: 1, 3
+    assert_eq!(result.values.to_vec(), vec![1, 3]);
+}
+
+#[test]
+fn test_union1d() {
+    let ar1 = Array::from_vec(vec![1, 2, 3]);
+    let ar2 = Array::from_vec(vec![2, 3, 4]);
+    let result = union1d(&ar1, &ar2).unwrap();
+    // Unique elements from both, sorted: 1, 2, 3, 4
+    assert_eq!(result.to_vec(), vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn test_setdiff1d() {
+    let ar1 = Array::from_vec(vec![1, 2, 3, 4, 1]);
+    let ar2 = Array::from_vec(vec![2, 4]);
+    let result = setdiff1d(&ar1, &ar2, false).unwrap();
+    // Unique elements in ar1 not in ar2, sorted: 1, 3
+    assert_eq!(result.to_vec(), vec![1, 3]);
+}
+
+#[test]
+fn test_setxor1d() {
+    let ar1 = Array::from_vec(vec![1, 2, 3, 2]);
+    let ar2 = Array::from_vec(vec![2, 3, 5, 5]);
+    let result = setxor1d(&ar1, &ar2, false).unwrap();
+    // Unique elements in ar1 or ar2 but not both, sorted: 1, 5
+    assert_eq!(result.to_vec(), vec![1, 5]);
 }


### PR DESCRIPTION
This PR implements , , , and  in . It also adds the  variant to  to match NumPy parity and ensures proper re-exports in .

Changes:
- Implemented 
- Implemented 
- Implemented 
- Implemented 
- Added  to 
- Fixed type inference issues in 
- Exported  in 
- Added comprehensive unit tests in 