### PR TITLE
fix(security): validate subprocess calls and use absolute paths (S603, S607, S112, S113)

### DIFF
--- a/examples/analyze_audio.py
+++ b/examples/analyze_audio.py
@@ -1,32 +1,43 @@
 import argparse
 import json
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
 
 def run_ffprobe(path: Path) -> dict[str, Any]:
+    ffprobe_path = shutil.which("ffprobe")
+    if ffprobe_path is None:
+        return {"error": "ffprobe not found"}
     try:
-        result = subprocess.run(
-            ["ffprobe", "-hide_banner", "-show_format", "-show_streams", "-of", "json", str(path)],
+        result = subprocess.run(  # noqa: S603 - executable validated with shutil.which
+            [
+                ffprobe_path,
+                "-hide_banner",
+                "-show_format",
+                "-show_streams",
+                "-of",
+                "json",
+                str(path),
+            ],
             check=True,
             capture_output=True,
             text=True,
         )
         return json.loads(result.stdout)
-    except FileNotFoundError:
-        return {"error": "ffprobe not found"}
     except subprocess.CalledProcessError as exc:
         return {"error": "ffprobe failed", "stderr": exc.stderr}
 
 
 def run_sox_stat(path: Path) -> dict[str, Any]:
-    try:
-        result = subprocess.run(
-            ["sox", str(path), "-n", "stat"], check=True, capture_output=True, text=True
-        )
-    except FileNotFoundError:
+    sox_path = shutil.which("sox")
+    if sox_path is None:
         return {"error": "sox not found"}
+    try:
+        result = subprocess.run(  # noqa: S603 - executable validated with shutil.which
+            [sox_path, str(path), "-n", "stat"], check=True, capture_output=True, text=True
+        )
     except subprocess.CalledProcessError as exc:
         return {"error": "sox failed", "stderr": exc.stderr}
 

--- a/pocket_tts/numpy_rs_ctypes.draft.py
+++ b/pocket_tts/numpy_rs_ctypes.draft.py
@@ -1,5 +1,8 @@
 import ctypes
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class RustLibraryLoader:
@@ -24,7 +27,8 @@ class RustLibraryLoader:
                     try:
                         self._lib = ctypes.CDLL(str(lib_path))
                         return
-                    except Exception:
+                    except Exception as exc:
+                        logger.debug("Failed to load library from %s: %s", lib_path, exc)
                         continue
 
 

--- a/pocket_tts/utils/utils.py
+++ b/pocket_tts/utils/utils.py
@@ -72,7 +72,7 @@ def download_if_necessary(file_path: str) -> Path:
             hashlib.sha256(file_path.encode()).hexdigest() + "." + file_path.split(".")[-1]
         )
         if not cached_file.exists():
-            response = requests.get(file_path)
+            response = requests.get(file_path, timeout=30)
             response.raise_for_status()
             with open(cached_file, "wb") as f:
                 f.write(response.content)

--- a/scripts/ralph-dashboard.py
+++ b/scripts/ralph-dashboard.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def parse_ts(s: str):
@@ -48,7 +51,8 @@ def main():
                 continue
             try:
                 rec = json.loads(line)
-            except Exception:
+            except Exception as exc:
+                logger.debug("Failed to parse JSON line in %s: %s", p, exc)
                 continue
             runs[run_id]["events"].append(rec)
             ts = parse_ts(rec.get("ts", ""))

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -69,7 +69,7 @@ def make_my_voice_file():
     import requests
 
     url = "https://huggingface.co/kyutai/tts-voices/resolve/main/expresso/ex01-ex02_default_001_channel1_168s.wav"
-    response = requests.get(url)
+    response = requests.get(url, timeout=60)
     with open("my_voice.wav", "wb") as f:
         f.write(response.content)
 


### PR DESCRIPTION
## Summary
- Fix S603/S607: subprocess calls with untrusted input and partial paths (2 instances)
  - examples/analyze_audio.py: Use shutil.which() to validate executables before subprocess calls
  - Added noqa comments to document review of subprocess calls
- Fix S112: try-except-continue should log exceptions (2 instances)
  - pocket_tts/numpy_rs_ctypes.draft.py: Add debug logging for library load failures
  - scripts/ralph-dashboard.py: Add debug logging for JSON parse failures
- Fix S113: requests calls should have timeouts (2 instances)
  - pocket_tts/utils/utils.py: Add 30s timeout to requests.get()
  - tests/test_documentation_examples.py: Add 60s timeout to requests.get()

## Verification
- Commands run:
  - `uv run ruff format .` - 1 file reformatted
  - `uv run ruff check .` - All checks passed (S603, S607, S112, S113)

## Notes / Follow-ups
- All subprocess calls now use validated absolute paths via shutil.which()
- All requests calls have appropriate timeouts to prevent hanging
- Exception logging added for better debugging of transient failures

Resolves #214