### PR TITLE
[rust-numpy] Implement allclose, isclose, array_equal, array_equiv

### DIFF
--- a/rust-numpy/src/comparison_ufuncs.rs
+++ b/rust-numpy/src/comparison_ufuncs.rs
@@ -466,3 +466,198 @@ where
         self.norm() == T::zero()
     }
 }
+
+// ==================== TOLERANCE-BASED COMPARISON FUNCTIONS ====================
+
+/// Check if two arrays are element-wise equal within tolerance
+///
+/// Returns a boolean array where each element is True if the corresponding
+/// elements of the input arrays are close within the specified tolerance.
+///
+/// # Arguments
+/// * `a` - First array
+/// * `b` - Second array
+/// * `rtol` - Relative tolerance (default: 1e-05)
+/// * `atol` - Absolute tolerance (default: 1e-08)
+/// * `equal_nan` - If True, consider NaN values as equal (default: false)
+///
+/// # Formula
+/// `|a - b| <= atol + rtol * |b|`
+///
+/// # Returns
+/// Boolean array indicating which elements are close
+pub fn isclose<T>(
+    a: &Array<T>,
+    b: &Array<T>,
+    rtol: Option<f64>,
+    atol: Option<f64>,
+    equal_nan: Option<bool>,
+) -> Result<Array<bool>>
+where
+    T: Clone + Default + Into<f64> + 'static + Send + Sync,
+{
+    let rtol = rtol.unwrap_or(1e-05);
+    let atol = atol.unwrap_or(1e-08);
+    let equal_nan = equal_nan.unwrap_or(false);
+
+    // Broadcast arrays if needed
+    let broadcasted = broadcast_arrays(&[a, b])?;
+    let a_broadcast = &broadcasted[0];
+    let b_broadcast = &broadcasted[1];
+
+    let size = a_broadcast.size();
+    let mut result = vec![false; size];
+
+    for i in 0..size {
+        let a_val = a_broadcast.get_linear(i).unwrap();
+        let b_val = b_broadcast.get_linear(i).unwrap();
+
+        let a_f64: f64 = a_val.clone().into();
+        let b_f64: f64 = b_val.clone().into();
+
+        // Handle NaN comparisons
+        if a_f64.is_nan() || b_f64.is_nan() {
+            result[i] = equal_nan && a_f64.is_nan() && b_f64.is_nan();
+            continue;
+        }
+
+        // Handle infinity comparisons
+        if a_f64.is_infinite() || b_f64.is_infinite() {
+            result[i] = a_f64 == b_f64;
+            continue;
+        }
+
+        // Standard tolerance comparison
+        let diff = (a_f64 - b_f64).abs();
+        let tolerance = atol + rtol * b_f64.abs();
+        result[i] = diff <= tolerance;
+    }
+
+    Ok(Array::from_vec(result)
+        .reshape(a_broadcast.shape())
+        .unwrap())
+}
+
+/// Check if two arrays are element-wise equal within tolerance
+///
+/// Returns True if all elements of the two arrays are equal within
+/// the specified tolerance.
+///
+/// # Arguments
+/// * `a` - First array
+/// * `b` - Second array
+/// * `rtol` - Relative tolerance (default: 1e-05)
+/// * `atol` - Absolute tolerance (default: 1e-08)
+/// * `equal_nan` - If True, consider NaN values as equal (default: false)
+///
+/// # Returns
+/// True if all elements are close, False otherwise
+pub fn allclose<T>(
+    a: &Array<T>,
+    b: &Array<T>,
+    rtol: Option<f64>,
+    atol: Option<f64>,
+    equal_nan: Option<bool>,
+) -> Result<bool>
+where
+    T: Clone + Default + Into<f64> + 'static + Send + Sync,
+{
+    let close_array = isclose(a, b, rtol, atol, equal_nan)?;
+
+    // Check if all elements are true
+    for i in 0..close_array.size() {
+        if let Some(&val) = close_array.get_linear(i) {
+            if !val {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// Check if two arrays are exactly equal
+///
+/// Returns True if arrays have the same shape and all elements are equal.
+/// This is a strict comparison that does not use tolerance.
+///
+/// # Arguments
+/// * `a1` - First array
+/// * `a2` - Second array
+///
+/// # Returns
+/// True if arrays are equal, False otherwise
+pub fn array_equal<T>(a1: &Array<T>, a2: &Array<T>) -> bool
+where
+    T: Clone + PartialEq + 'static,
+{
+    // Check shape equality
+    if a1.shape() != a2.shape() {
+        return false;
+    }
+
+    // Check element equality
+    for i in 0..a1.size() {
+        let val1 = a1.get_linear(i);
+        let val2 = a2.get_linear(i);
+
+        match (val1, val2) {
+            (Some(v1), Some(v2)) => {
+                if v1 != v2 {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+/// Check if two arrays are element-wise equivalent (broadcasting allowed)
+///
+/// Returns True if arrays are element-wise equal after broadcasting.
+/// Unlike array_equal, this function allows broadcasting.
+///
+/// # Arguments
+/// * `a1` - First array
+/// * `a2` - Second array
+///
+/// # Returns
+/// True if arrays are equivalent, False otherwise
+pub fn array_equiv<T>(a1: &Array<T>, a2: &Array<T>) -> bool
+where
+    T: Clone + PartialEq + Default + 'static,
+{
+    // Try to broadcast arrays
+    let broadcasted = match broadcast_arrays(&[a1, a2]) {
+        Ok(arrs) => arrs,
+        Err(_) => return false,
+    };
+
+    let a1_broadcast = &broadcasted[0];
+    let a2_broadcast = &broadcasted[1];
+
+    // Check element equality
+    for i in 0..a1_broadcast.size() {
+        let val1 = a1_broadcast.get_linear(i);
+        let val2 = a2_broadcast.get_linear(i);
+
+        match (val1, val2) {
+            (Some(v1), Some(v2)) => {
+                if v1 != v2 {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+// ==================== PUBLIC EXPORTS ====================
+
+/// Re-export comparison functions for public use
+pub mod exports {
+    pub use super::{allclose, array_equal, array_equiv, isclose};
+}

--- a/rust-numpy/src/lib.rs
+++ b/rust-numpy/src/lib.rs
@@ -66,6 +66,7 @@ pub mod window;
 
 // Re-export key types for convenience
 pub use crate::array_extra::exports::*;
+pub use crate::comparison_ufuncs::exports::*;
 pub use crate::fft::*;
 pub use array::Array;
 pub use array_manipulation::exports::*;

--- a/rust-numpy/tests/comparison_funcs_tests.rs
+++ b/rust-numpy/tests/comparison_funcs_tests.rs
@@ -1,0 +1,145 @@
+use numpy::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allclose_basic() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert!(allclose(&a, &b, None, None, None).unwrap());
+    }
+
+    #[test]
+    fn test_allclose_with_tolerance() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0001, 2.0001, 3.0001]);
+        assert!(allclose(&a, &b, Some(1e-4), Some(1e-4), None).unwrap());
+    }
+
+    #[test]
+    fn test_allclose_failure() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0, 2.5, 3.0]);
+        assert!(!allclose(&a, &b, None, None, None).unwrap());
+    }
+
+    #[test]
+    fn test_allclose_with_nan_equal() {
+        let a = Array::from_vec(vec![1.0, f64::NAN, 3.0]);
+        let b = Array::from_vec(vec![1.0, f64::NAN, 3.0]);
+        assert!(allclose(&a, &b, None, None, Some(true)).unwrap());
+    }
+
+    #[test]
+    fn test_allclose_with_nan_not_equal() {
+        let a = Array::from_vec(vec![1.0, f64::NAN, 3.0]);
+        let b = Array::from_vec(vec![1.0, f64::NAN, 3.0]);
+        assert!(!allclose(&a, &b, None, None, Some(false)).unwrap());
+    }
+
+    #[test]
+    fn test_isclose_element_wise() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0001, 2.5, 3.0001]);
+        let result = isclose(&a, &b, Some(1e-4), Some(1e-4), None).unwrap();
+        assert_eq!(result.shape(), &[3]);
+        assert_eq!(result.get_linear(0).unwrap(), &true);
+        assert_eq!(result.get_linear(1).unwrap(), &false);
+        assert_eq!(result.get_linear(2).unwrap(), &true);
+    }
+
+    #[test]
+    fn test_isclose_broadcasting() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![2.0]);
+        let result = isclose(&a, &b, None, Some(1.0), None).unwrap();
+        assert_eq!(result.shape(), &[3]);
+    }
+
+    #[test]
+    fn test_array_equal_identical() {
+        let a = Array::from_vec(vec![1, 2, 3]);
+        let b = Array::from_vec(vec![1, 2, 3]);
+        assert!(array_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equal_different() {
+        let a = Array::from_vec(vec![1, 2, 3]);
+        let b = Array::from_vec(vec![1, 2, 4]);
+        assert!(!array_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equal_different_shape() {
+        let a = Array::from_vec(vec![1, 2, 3]);
+        let b = Array::from_vec(vec![1, 2]);
+        assert!(!array_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equal_2d() {
+        let a = array2![[1, 2], [3, 4]];
+        let b = array2![[1, 2], [3, 4]];
+        assert!(array_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equiv_broadcasting() {
+        let a = Array::from_vec(vec![1, 1, 1]);
+        let b = Array::from_vec(vec![1]);
+        assert!(array_equiv(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equiv_no_broadcasting() {
+        let a = Array::from_vec(vec![1, 2, 3]);
+        let b = Array::from_vec(vec![1, 2, 3]);
+        assert!(array_equiv(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equiv_different_values() {
+        let a = Array::from_vec(vec![1, 2, 3]);
+        let b = Array::from_vec(vec![1, 2, 4]);
+        assert!(!array_equiv(&a, &b));
+    }
+
+    #[test]
+    fn test_allclose_infinity() {
+        let a = Array::from_vec(vec![f64::INFINITY, 1.0]);
+        let b = Array::from_vec(vec![f64::INFINITY, 1.0]);
+        assert!(allclose(&a, &b, None, None, None).unwrap());
+    }
+
+    #[test]
+    fn test_allclose_different_infinity() {
+        let a = Array::from_vec(vec![f64::INFINITY, 1.0]);
+        let b = Array::from_vec(vec![f64::NEG_INFINITY, 1.0]);
+        assert!(!allclose(&a, &b, None, None, None).unwrap());
+    }
+
+    #[test]
+    fn test_array_equal_scalar() {
+        let a = Array::from_scalar(42, vec![]);
+        let b = Array::from_scalar(42, vec![]);
+        assert!(array_equal(&a, &b));
+    }
+
+    #[test]
+    fn test_array_equiv_scalar_broadcast() {
+        let a = Array::from_vec(vec![1, 1, 1]);
+        let b = Array::from_scalar(1, vec![]);
+        assert!(array_equiv(&a, &b));
+    }
+
+    #[test]
+    fn test_isclose_default_parameters() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.00001, 2.00001, 3.00001]);
+        let result = isclose(&a, &b, None, None, None).unwrap();
+        assert_eq!(result.get_linear(0).unwrap(), &true);
+    }
+}

--- a/rust-numpy/tests/mod.rs
+++ b/rust-numpy/tests/mod.rs
@@ -6,6 +6,7 @@ pub mod array_clip_round_ptp_tests;
 pub mod array_extra_tests;
 pub mod basic_tests;
 pub mod choose_compress_tests;
+pub mod comparison_funcs_tests;
 pub mod comparison_tests;
 pub mod comprehensive_tests;
 pub mod conformance_tests;


### PR DESCRIPTION
## Summary
- Implement `allclose<T>(a, b, rtol, atol, equal_nan)` - returns bool if all elements close
- Implement `isclose<T>(a, b, rtol, atol, equal_nan)` - element-wise closeness array
- Implement `array_equal<T>(a1, a2)` - strict shape and element equality
- Implement `array_equiv<T>(a1, a2)` - element-wise equality with broadcasting support
- Handle NaN, infinity, and tolerance comparisons correctly

## Changes
- Added tolerance-based comparison functions to `rust-numpy/src/comparison_ufuncs.rs`
- Added exports module for comparison functions
- Updated `rust-numpy/src/lib.rs` to export comparison functions
- Added comprehensive tests in `rust-numpy/tests/comparison_funcs_tests.rs`
- Updated `rust-numpy/tests/mod.rs` to include new test module

## Verification
- Commands run:
  - `cargo test --test comparison_funcs_tests` (19/19 tests passed)

## Notes / Follow-ups
- Formula: `|a - b| <= atol + rtol * |b|`
- NaN comparisons respect the `equal_nan` parameter
- Infinity comparisons work correctly (inf == inf, inf != -inf)
- Broadcasting is supported for isclose and array_equiv

Resolves #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)