### PR TITLE
[rust-numpy] Implement QR mode='r'

### DIFF
--- a/rust-numpy/src/linalg/solvers.rs
+++ b/rust-numpy/src/linalg/solvers.rs
@@ -269,7 +269,10 @@ where
         return Err(NumPyError::shape_mismatch(vec![m], vec![b.shape()[0]]));
     }
 
-    let (q, r) = qr(a, "reduced")?;
+    let (q, r) = match qr(a, "reduced")? {
+        crate::linalg::decompositions::QRResult::QR(q, r) => (q, r),
+        _ => unreachable!(),
+    };
 
     // Compute d = Q.T @ b
     let q_t = q.transpose();

--- a/rust-numpy/tests/linalg_qr_tests.rs
+++ b/rust-numpy/tests/linalg_qr_tests.rs
@@ -1,13 +1,16 @@
 use approx::assert_abs_diff_eq;
-use numpy::array2;
-use numpy::linalg::qr;
+use numpy::linalg::{qr, QRResult};
+use numpy::{array2, Array};
 
 #[test]
 fn test_qr_basic_reduced() {
     let a = array2![[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]; // 3x2 matrix
 
     // Default mode is "reduced" -> Q (3x2), R (2x2)
-    let (q, r) = qr(&a, "reduced").unwrap();
+    let (q, r) = match qr(&a, "reduced").unwrap() {
+        QRResult::QR(q, r) => (q, r),
+        _ => panic!("Expected QR"),
+    };
 
     // Check shapes
     assert_eq!(q.shape(), &[3, 2]);
@@ -33,7 +36,10 @@ fn test_qr_basic_reduced() {
 #[test]
 fn test_qr_1x1() {
     let a = array2![[2.0]];
-    let (q, r) = qr(&a, "reduced").unwrap();
+    let (q, r) = match qr(&a, "reduced").unwrap() {
+        QRResult::QR(q, r) => (q, r),
+        _ => panic!("Expected QR"),
+    };
     // 1x1 QR of [2.0]: Q=[1.0], R=[2.0] (or signs flipped)
     // Q orthonormal -> [1.0] or [-1.0]
     // A = Q R
@@ -44,4 +50,33 @@ fn test_qr_1x1() {
         reconstructed.get_linear(0).unwrap(),
         a.get_linear(0).unwrap()
     );
+}
+
+#[test]
+fn test_qr_mode_r() {
+    let a: Array<f64> = array2![[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
+    let res = qr(&a, "r").unwrap();
+
+    match res {
+        QRResult::R(r) => {
+            assert_eq!(r.shape(), &[2, 2]);
+            // R should be upper triangular
+            assert!(r.get_multi(&[1, 0]).unwrap().abs() < 1e-10);
+
+            // Check diagonal values (must be same as reduced QR's R)
+            let res_full = qr(&a, "reduced").unwrap();
+            if let QRResult::QR(_, r_full) = res_full {
+                for i in 0..2 {
+                    for j in 0..2 {
+                        let val = r.get_multi(&[i, j]).unwrap();
+                        let val_full = r_full.get_multi(&[i, j]).unwrap();
+                        assert_abs_diff_eq!(val, val_full, epsilon = 1e-10);
+                    }
+                }
+            } else {
+                panic!("Expected QR");
+            }
+        }
+        _ => panic!("Expected QRResult::R"),
+    }
 }


### PR DESCRIPTION
Closes #261. Implemented support for 'r' mode in QR decomposition, returning only the R matrix. Introduced QRResult enum for dynamic return types and optimized Householder application to skip Q matrix computation when not requested.