### PR TITLE
feat(rust-numpy): implement axis parameter for linalg.norm

### DIFF
--- a/rust-numpy/tests/conformance_tests.rs
+++ b/rust-numpy/tests/conformance_tests.rs
@@ -415,20 +415,20 @@ mod tests {
         "L1 norm should compute sum of absolute values",
         {
             let arr = Array::from_vec(vec![1.0f64, -2.0, 3.0, -4.0]);
-            let result = numpy::norm(&arr, Some("1"), None, false).unwrap();
+            let result = numpy::norm(&arr, Some("1"), None::<&[isize]>, false).unwrap();
             assert_eq!(result.to_vec(), vec![10.0]); // |1| + |-2| + |3| + |-4| = 10
         }
     );
 
     conformance_test!(test_norm_l2, "L2 norm should compute Euclidean norm", {
         let arr = Array::from_vec(vec![3.0f64, 4.0]);
-        let result = numpy::norm(&arr, Some("2"), None, false).unwrap();
+        let result = numpy::norm(&arr, Some("2"), None::<&[isize]>, false).unwrap();
         assert!((result.to_vec()[0] - 5.0).abs() < 1e-10); // sqrt(3^2 + 4^2) = 5
     });
 
     conformance_test!(test_norm_l3, "L3 norm should compute cubic norm", {
         let arr = Array::from_vec(vec![1.0f64, 2.0, 2.0]);
-        let result = numpy::norm(&arr, Some("3"), None, false).unwrap();
+        let result = numpy::norm(&arr, Some("3"), None::<&[isize]>, false).unwrap();
         // (|1|^3 + |2|^3 + |2|^3)^(1/3) = (1 + 8 + 8)^(1/3) = 17^(1/3) ≈ 2.571
         assert!((result.to_vec()[0] - 2.571).abs() < 1e-3);
     });
@@ -438,7 +438,7 @@ mod tests {
         "Frobenius norm should compute sqrt of sum of squares",
         {
             let arr = Array::from_vec(vec![1.0f64, 2.0, 3.0]);
-            let result = numpy::norm(&arr, Some("fro"), None, false).unwrap();
+            let result = numpy::norm(&arr, Some("fro"), None::<&[isize]>, false).unwrap();
             // sqrt(1^2 + 2^2 + 3^2) = sqrt(14) ≈ 3.742
             assert!((result.to_vec()[0] - 3.742).abs() < 1e-3);
         }
@@ -449,7 +449,7 @@ mod tests {
         "Nuclear norm should compute sum of singular values",
         {
             let arr = Array::from_vec(vec![1.0f64, 2.0, 3.0]);
-            let result = numpy::norm(&arr, Some("nuc"), None, false).unwrap();
+            let result = numpy::norm(&arr, Some("nuc"), None::<&[isize]>, false).unwrap();
             // Nuclear norm is approximated by Frobenius norm for now
             // sqrt(1^2 + 2^2 + 3^2) = sqrt(14) ≈ 3.742
             assert!((result.to_vec()[0] - 3.742).abs() < 1e-3);
@@ -461,7 +461,7 @@ mod tests {
         "Default norm should use Frobenius norm for vectors",
         {
             let arr = Array::from_vec(vec![3.0f64, 4.0]);
-            let result = numpy::norm(&arr, None, None, false).unwrap();
+            let result = numpy::norm(&arr, None, None::<&[isize]>, false).unwrap();
             // Default is Frobenius norm: sqrt(3^2 + 4^2) = 5
             assert!((result.to_vec()[0] - 5.0).abs() < 1e-10);
         }

--- a/rust-numpy/tests/norm_axis_tests.rs
+++ b/rust-numpy/tests/norm_axis_tests.rs
@@ -1,0 +1,203 @@
+use numpy::*;
+
+#[test]
+fn test_norm_axis_0_2d() {
+    // Test L2 norm along axis 0 of a 2D array
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![3, 4], data);
+
+    let result = norm(&arr, Some("2"), Some(&[0isize]), false).unwrap();
+
+    // Expected: sqrt(1^2 + 5^2 + 9^2), sqrt(2^2 + 6^2 + 10^2), etc.
+    // sqrt(1 + 25 + 81) = sqrt(107) ≈ 10.344
+    // sqrt(4 + 36 + 100) = sqrt(140) ≈ 11.832
+    // sqrt(9 + 49 + 121) = sqrt(179) ≈ 13.379
+    // sqrt(16 + 64 + 144) = sqrt(224) ≈ 14.967
+    assert_eq!(result.shape(), &[4]);
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 10.344).abs() < 0.01);
+    assert!((result_vec[1] - 11.832).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_axis_1_2d() {
+    // Test L2 norm along axis 1 of a 2D array
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![3, 4], data);
+
+    let result = norm(&arr, Some("2"), Some(&[1isize]), false).unwrap();
+
+    // Expected: sqrt(1^2 + 2^2 + 3^2 + 4^2) = sqrt(30) ≈ 5.477
+    // sqrt(5^2 + 6^2 + 7^2 + 8^2) = sqrt(174) ≈ 13.191
+    // sqrt(9^2 + 10^2 + 11^2 + 12^2) = sqrt(446) ≈ 21.119
+    assert_eq!(result.shape(), &[3]);
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 5.477).abs() < 0.01);
+    assert!((result_vec[1] - 13.191).abs() < 0.01);
+    assert!((result_vec[2] - 21.119).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_axis_negative() {
+    // Test negative axis indexing
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![3, 4], data);
+
+    let result = norm(&arr, Some("2"), Some(&[-1isize]), false).unwrap();
+
+    // axis=-1 should be the same as axis=1
+    assert_eq!(result.shape(), &[3]);
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 5.477).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_axis_keepdims() {
+    // Test keepdims parameter
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![3, 4], data);
+
+    let result = norm(&arr, Some("2"), Some(&[0isize]), true).unwrap();
+
+    // With keepdims, shape should be [1, 4]
+    assert_eq!(result.shape(), &[1, 4]);
+}
+
+#[test]
+fn test_norm_axis_multiple() {
+    // Test reduction along multiple axes
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+        17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0,
+    ];
+    let arr = Array::from_shape_vec(vec![2, 3, 4], data);
+
+    let result = norm(&arr, Some("2"), Some(&[0isize, 1isize]), false).unwrap();
+
+    // Should reduce to shape [4]
+    assert_eq!(result.shape(), &[4]);
+
+    // Compute expected: sqrt(sum of squares along axes 0 and 1)
+    // For position 0: sqrt(1^2 + 5^2 + 9^2 + 13^2 + 17^2 + 21^2)
+    // = sqrt(1 + 25 + 81 + 169 + 289 + 441) = sqrt(1006) ≈ 31.717
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 31.717).abs() < 0.1);
+}
+
+#[test]
+fn test_norm_l1_axis() {
+    // Test L1 norm along an axis
+    let data: Vec<f64> = vec![1.0, -2.0, 3.0, -4.0, 5.0, -6.0];
+    let arr = Array::from_shape_vec(vec![2, 3], data);
+
+    let result = norm(&arr, Some("1"), Some(&[0isize]), false).unwrap();
+
+    // L1 norm along axis 0: sum of absolute values
+    // |1| + |-4| = 5, |-2| + |5| = 7, |3| + |-6| = 9
+    assert_eq!(result.shape(), &[3]);
+    assert_eq!(result.to_vec(), vec![5.0, 7.0, 9.0]);
+}
+
+#[test]
+fn test_norm_inf_axis() {
+    // Test L-infinity norm along an axis
+    let data: Vec<f64> = vec![1.0, -5.0, 3.0, -4.0, 2.0, -6.0];
+    let arr = Array::from_shape_vec(vec![2, 3], data);
+
+    let result = norm(&arr, Some("inf"), Some(&[0isize]), false).unwrap();
+
+    // L-inf norm along axis 0: max of absolute values
+    // max(|1|, |-4|) = 4, max(|-5|, |2|) = 5, max(|3|, |-6|) = 6
+    assert_eq!(result.shape(), &[3]);
+    assert_eq!(result.to_vec(), vec![4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn test_norm_neg_inf_axis() {
+    // Test L-negative-infinity norm along an axis
+    let data: Vec<f64> = vec![1.0, -5.0, 3.0, -4.0, 2.0, -6.0];
+    let arr = Array::from_shape_vec(vec![2, 3], data);
+
+    let result = norm(&arr, Some("-inf"), Some(&[0isize]), false).unwrap();
+
+    // L-neg-inf norm along axis 0: min of absolute values
+    // min(|1|, |-4|) = 1, min(|-5|, |2|) = 2, min(|3|, |-6|) = 3
+    assert_eq!(result.shape(), &[3]);
+    assert_eq!(result.to_vec(), vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn test_norm_3d_axis_0() {
+    // Test norm on 3D array along axis 0
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![2, 3, 2], data);
+
+    let result = norm(&arr, Some("2"), Some(&[0isize]), false).unwrap();
+
+    // Shape should be [3, 2]
+    assert_eq!(result.shape(), &[3, 2]);
+
+    // Check first element: sqrt(1^2 + 7^2) = sqrt(50) ≈ 7.071
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 7.071).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_3d_axis_1() {
+    // Test norm on 3D array along axis 1
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![2, 3, 2], data);
+
+    let result = norm(&arr, Some("2"), Some(&[1isize]), false).unwrap();
+
+    // Shape should be [2, 2]
+    assert_eq!(result.shape(), &[2, 2]);
+
+    // Check first element: sqrt(1^2 + 3^2 + 5^2) = sqrt(35) ≈ 5.916
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 5.916).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_3d_axis_2() {
+    // Test norm on 3D array along axis 2
+    let data: Vec<f64> = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+    ];
+    let arr = Array::from_shape_vec(vec![2, 3, 2], data);
+
+    let result = norm(&arr, Some("2"), Some(&[2isize]), false).unwrap();
+
+    // Shape should be [2, 3]
+    assert_eq!(result.shape(), &[2, 3]);
+
+    // Check first element: sqrt(1^2 + 2^2) = sqrt(5) ≈ 2.236
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 2.236).abs() < 0.01);
+}
+
+#[test]
+fn test_norm_fro_with_axis() {
+    // Test that Frobenius norm works with axis
+    let data: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let arr = Array::from_shape_vec(vec![2, 3], data);
+
+    let result = norm(&arr, Some("fro"), Some(&[0isize]), false).unwrap();
+
+    // Frobenius along axis 0 should be same as L2
+    assert_eq!(result.shape(), &[3]);
+    let result_vec = result.to_vec();
+    assert!((result_vec[0] - 4.123).abs() < 0.01); // sqrt(1^2 + 4^2)
+}


### PR DESCRIPTION
## Summary
Implement comprehensive axis parameter support for the `linalg.norm` function, enabling reduction along single or multiple axes with full NumPy compatibility.

## Changes
- **API Change**: Modified `norm` signature from `axis: Option<usize>` to `axis: Option<&[isize]>`
- **Features**:
  - Single axis reduction (e.g., `axis=0`, `axis=-1`)
  - Multiple axis reduction (e.g., `axis=(0,1)`)
  - Negative axis indexing support
  - `keepdims` parameter support
  - L-infinity and L-negative-infinity norms
  - Negative Lp norms
- **Implementation**:
  - Added `normalize_axis` and `normalize_axes` helper functions
  - Implemented `compute_norm_with_axis` for Lp norms with axis reduction
  - Implemented `compute_norm_inf_with_axis` for L-inf norms
  - Implemented `compute_norm_neg_p_with_axis` for negative Lp norms
  - Proper output shape computation with `compute_output_shape`
- **Tests**: Added comprehensive test suite (`norm_axis_tests.rs`) with 12 tests covering:
  - 2D arrays with various axes
  - 3D arrays with axis 0, 1, 2
  - Negative axis indexing
  - keepdims behavior
  - Multiple axis reduction
  - L1, L2, L-inf, L-neg-inf, and Frobenius norms

## Test Results
✅ All 12 new tests passing
✅ Existing conformance tests updated and passing
✅ `cargo fmt` passes
✅ `cargo test --package rust-numpy` passes

## Acceptance Criteria
- [x] `norm(a, axis=0)` returns indices of max along axis 0
- [x] `norm(a, axis=-1)` supports negative axis
- [x] `norm(a, axis=(0,1))` supports multiple axes
- [x] `keepdims=True` preserves reduced dimensions
- [x] Works correctly for N-D arrays
- [x] Unit tests for edge cases

## Verification
```bash
cargo fmt --check
cargo clippy --package rust-numpy -- -D warnings
cargo test --package rust-numpy --test norm_axis_tests
```

Resolves #260