### PR TITLE
fix: Correctly handle broadcasting of 0-sized dimensions

### DIFF
--- a/rust-numpy/src/strides.rs
+++ b/rust-numpy/src/strides.rs
@@ -132,7 +132,15 @@ pub fn compute_broadcast_shape(shape1: &[usize], shape2: &[usize]) -> Vec<usize>
             1
         };
 
-        result[i] = std::cmp::max(dim1, dim2);
+        result[i] = if dim1 == 1 {
+            dim2
+        } else if dim2 == 1 {
+            dim1
+        } else {
+            // Dimensions match (e.g., 0 and 0, or 3 and 3)
+            // Note: Incompatible shapes should be checked via are_shapes_broadcastable before calling this
+            dim1
+        };
     }
 
     result

--- a/rust-numpy/tests/broadcasting_edge_cases.rs
+++ b/rust-numpy/tests/broadcasting_edge_cases.rs
@@ -1,0 +1,46 @@
+use numpy::strides::compute_broadcast_shape;
+use numpy::Array;
+
+#[test]
+fn test_broadcast_zero_and_one() {
+    let shape1 = vec![0];
+    let shape2 = vec![1];
+
+    // According to NumPy: np.broadcast_shapes((0,), (1,)) -> (0,)
+    let result = compute_broadcast_shape(&shape1, &shape2);
+    assert_eq!(
+        result,
+        vec![0],
+        "Broadcasting (0,) and (1,) should result in (0,)"
+    );
+}
+
+#[test]
+fn test_broadcast_zero_and_zero() {
+    let shape1 = vec![0];
+    let shape2 = vec![0];
+    let result = compute_broadcast_shape(&shape1, &shape2);
+    assert_eq!(
+        result,
+        vec![0],
+        "Broadcasting (0,) and (0,) should result in (0,)"
+    );
+}
+
+#[test]
+fn test_broadcast_mixed_dims() {
+    // (0, 3) and (1, 3) -> (0, 3)
+    let shape1 = vec![0, 3];
+    let shape2 = vec![1, 3];
+    let result = compute_broadcast_shape(&shape1, &shape2);
+    assert_eq!(result, vec![0, 3]);
+}
+
+#[test]
+fn test_broadcast_mixed_dims_2() {
+    // (0, 3) and (1, 1) -> (0, 3)
+    let shape1 = vec![0, 3];
+    let shape2 = vec![1, 1];
+    let result = compute_broadcast_shape(&shape1, &shape2);
+    assert_eq!(result, vec![0, 3]);
+}


### PR DESCRIPTION
Fixes a bug where broadcasting arrays with 0-sized dimensions against 1-sized dimensions yielded incorrect shapes (using max instead of 0). Adds regression tests.