### PR TITLE
feat(polynomial): implement set_default_printstyle function

### DIFF
--- a/rust-numpy/src/polynomial/exports.rs
+++ b/rust-numpy/src/polynomial/exports.rs
@@ -7,3 +7,4 @@ pub use super::hermite_e::*;
 pub use super::laguerre::*;
 pub use super::legendre::*;
 pub use super::polynomial::*;
+pub use super::{set_default_printstyle};

--- a/rust-numpy/tests/polynomial_tests.rs
+++ b/rust-numpy/tests/polynomial_tests.rs
@@ -1,6 +1,6 @@
 use ndarray::array;
 
-use numpy::polynomial::{fit, roots, Polynomial, PolynomialBase};
+use numpy::polynomial::{fit, roots, set_default_printstyle, Polynomial, PolynomialBase};
 
 #[test]
 fn test_poly_eval() {
@@ -201,4 +201,19 @@ fn test_fit_higher_degree() {
     assert!((coeffs[0] - 1.0_f64).abs() < 1e-6);
     assert!((coeffs[1] - 2.0_f64).abs() < 1e-6);
     assert!((coeffs[2] - 1.0_f64).abs() < 1e-6);
+}
+
+#[test]
+fn test_set_default_printstyle() {
+    // Test setting unicode style
+    assert!(set_default_printstyle("unicode").is_ok());
+
+    // Test setting ascii style
+    assert!(set_default_printstyle("ascii").is_ok());
+
+    // Test invalid style
+    assert!(set_default_printstyle("invalid").is_err());
+
+    // Verify we can switch back to unicode
+    assert!(set_default_printstyle("unicode").is_ok());
 }


### PR DESCRIPTION
## Summary
- Implemented `numpy.polynomial.set_default_printstyle` function to match NumPy 2.4 API parity
- Added global atomic state to store print style preference (unicode/ascii)
- Function validates input and supports both 'unicode' and 'ascii' styles
- Proper error handling for invalid style values

## Verification
- Commands run:
  - `cargo build --release` - Build succeeded
  - `cargo test --test polynomial_tests` - All 15 tests passed (14 existing + 1 new)
  - Test coverage for `set_default_printstyle` includes:
    - Setting unicode style
    - Setting ascii style
    - Error handling for invalid style

## Notes / Follow-ups
- The print style preference is stored in an atomic bool for thread-safe access
- Default style is unicode on Unix systems, ascii on Windows (via cfg!(unix))
- The function is now exported from the polynomial module for public use

Resolves #388

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>