### PR TITLE
feat(rust-numpy): add sorting methods to Array struct

### DIFF
--- a/rust-numpy/src/array.rs
+++ b/rust-numpy/src/array.rs
@@ -621,6 +621,65 @@ impl<T> Array<T> {
         }
         Self::from_data(data, vec![size, size])
     }
+
+    // ===== Sorting Methods =====
+
+    /// Sort array in-place or return a sorted copy
+    pub fn sort(&mut self, axis: Option<isize>, kind: &str, order: &str) -> Result<Self, NumPyError>
+    where
+        T: Clone + PartialOrd + crate::sorting::ComparisonOps<T> + Default + Send + Sync + 'static,
+    {
+        crate::sorting::sort(self, axis, kind, order)
+    }
+
+    /// Return indices that would sort the array
+    pub fn argsort(&self, axis: Option<isize>, kind: &str, order: &str) -> Result<Array<isize>, NumPyError>
+    where
+        T: Clone + PartialOrd + crate::sorting::ComparisonOps<T> + Default + Send + Sync + 'static,
+    {
+        crate::sorting::argsort(self, axis, kind, order)
+    }
+
+    /// Find insertion points for elements in a sorted array
+    pub fn searchsorted(
+        &self,
+        v: &Array<T>,
+        side: &str,
+        sorter: Option<&Array<isize>>,
+    ) -> Result<Array<isize>, NumPyError>
+    where
+        T: Clone + PartialOrd + crate::sorting::ComparisonOps<T> + Default + Send + Sync + 'static,
+    {
+        crate::sorting::searchsorted(self, v, side, sorter)
+    }
+
+    /// Return the indices that would partition an array
+    pub fn argpartition(
+        &self,
+        kth: crate::sorting::ArrayOrInt,
+        axis: Option<isize>,
+        kind: &str,
+        order: &str,
+    ) -> Result<Array<isize>, NumPyError>
+    where
+        T: Clone + PartialOrd + crate::sorting::ComparisonOps<T> + Default + Send + Sync + 'static,
+    {
+        crate::sorting::argpartition(self, kth, axis, kind, order)
+    }
+
+    /// Partition array in-place
+    pub fn partition(
+        &mut self,
+        kth: crate::sorting::ArrayOrInt,
+        axis: Option<isize>,
+        kind: &str,
+        order: &str,
+    ) -> Result<Self, NumPyError>
+    where
+        T: Clone + PartialOrd + crate::sorting::ComparisonOps<T> + Default + Send + Sync + 'static,
+    {
+        crate::sorting::partition(self, kth, axis, kind, order)
+    }
 }
 
 /// Compute strides from shape


### PR DESCRIPTION
## Summary
Add 5 sorting methods as Array struct methods for NumPy API parity.

## Changes
- **sort()**: Sort array in-place or return sorted copy
- **argsort()**: Return indices that would sort array
- **searchsorted()**: Find insertion points in sorted array
- **argpartition()**: Return indices that would partition array
- **partition()**: Partition array in-place

These are convenience wrappers around existing sorting module functions,
matching NumPy's ndarray API where methods are called directly on arrays.

## Test Results
- 190 tests passed
- 10 tests failed (pre-existing failures in bitwise, dtype, fft modules)
- All sorting module tests passed

## Resolves
Resolves #413

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>