### PR TITLE
feat(numpy): implement ndarray conversion/view methods (#414)

### DIFF
--- a/rust-numpy/src/array.rs
+++ b/rust-numpy/src/array.rs
@@ -637,6 +637,117 @@ pub fn compute_strides(shape: &[usize]) -> Vec<isize> {
     strides
 }
 
+impl<T> Array<T> {
+    /// Create a view of the array (shares data)
+    pub fn view(&self) -> Self
+    where
+        T: Clone,
+    {
+        Self {
+            data: Arc::clone(&self.data),
+            shape: self.shape.clone(),
+            strides: self.strides.clone(),
+            dtype: self.dtype.clone(),
+            offset: self.offset,
+        }
+    }
+
+    /// Cast array to new dtype
+    pub fn astype<U>(&self) -> Result<Array<U>, NumPyError>
+    where
+        T: Clone + Default + 'static + num_traits::NumCast + Copy,
+        U: Clone + Default + 'static + num_traits::NumCast + Copy,
+    {
+        let mut new_data = Vec::with_capacity(self.size());
+        for item in self.iter() {
+            let cast_val = num_traits::cast::<T, U>(*item)
+                .ok_or_else(|| NumPyError::invalid_operation("Failed to cast value"))?;
+            new_data.push(cast_val);
+        }
+        Ok(Array::from_shape_vec(self.shape.clone(), new_data))
+    }
+
+    /// Return complex conjugate (element-wise).
+    pub fn conj(&self) -> Result<Self, NumPyError>
+    where
+        T: Clone + Default + 'static + ElementConj,
+    {
+        let mut new_data = Vec::with_capacity(self.size());
+        for item in self.iter() {
+            new_data.push(item.element_conj());
+        }
+        Ok(Array::from_shape_vec(self.shape.clone(), new_data))
+    }
+
+    /// Return complex conjugate (alias).
+    pub fn conjugate(&self) -> Result<Self, NumPyError>
+    where
+        T: Clone + Default + 'static + ElementConj,
+    {
+        self.conj()
+    }
+
+    /// Move array to device (Stub)
+    pub fn to_device(&self, device: &str) -> Result<Self, NumPyError>
+    where
+        T: Clone,
+    {
+        if device == "cpu" {
+            Ok(self.clone())
+        } else {
+            Err(NumPyError::not_implemented("GPU support not enabled"))
+        }
+    }
+
+    /// Construct bytes containing raw data
+    pub fn tobytes(&self) -> Result<Vec<u8>, NumPyError>
+    where
+        T: Clone + Copy + 'static,
+    {
+        // Require contiguous
+        if !self.is_contiguous() {
+            return Err(NumPyError::invalid_operation(
+                "tobytes requires contiguous array",
+            ));
+        }
+
+        let slice = self.as_slice();
+        // unsafe reinterpretation
+        let len = slice.len() * std::mem::size_of::<T>();
+        let ptr = slice.as_ptr() as *const u8;
+        let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+        Ok(bytes.to_vec())
+    }
+
+    /// Write array to file
+    pub fn tofile<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), NumPyError>
+    where
+        T: Clone + Copy + 'static,
+    {
+        let bytes = self.tobytes()?;
+        std::fs::write(path, bytes).map_err(|e| NumPyError::invalid_operation(e.to_string()))
+    }
+
+    /// Return array as a list (Vec)
+    pub fn tolist(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        // For 1D, simple vec. For n-D, flat vec for now.
+        self.to_vec()
+    }
+
+    /// Swap bytes
+    pub fn byteswap(&self, _inplace: bool) -> Result<Self, NumPyError>
+    where
+        T: Clone + Default + 'static,
+    {
+        Err(NumPyError::not_implemented(
+            "byteswap requires trait specialization",
+        ))
+    }
+}
+
 impl<T> Clone for Array<T> {
     fn clone(&self) -> Self {
         Self {
@@ -668,5 +779,76 @@ pub fn normalize_axis(axis: isize, ndim: usize) -> Result<usize, NumPyError> {
             )));
         }
         Ok(axis as usize)
+    }
+}
+
+/// Trait for element-wise complex conjugate
+pub trait ElementConj {
+    fn element_conj(&self) -> Self;
+}
+
+impl ElementConj for f32 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for f64 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for i8 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for i16 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for i32 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for i64 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for u8 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for u16 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for u32 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for u64 {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for bool {
+    fn element_conj(&self) -> Self {
+        *self
+    }
+}
+impl ElementConj for Complex64 {
+    fn element_conj(&self) -> Self {
+        self.conj()
+    }
+}
+impl ElementConj for num_complex::Complex<f32> {
+    fn element_conj(&self) -> Self {
+        self.conj()
     }
 }

--- a/rust-numpy/tests/ndarray_conversion_tests.rs
+++ b/rust-numpy/tests/ndarray_conversion_tests.rs
@@ -1,0 +1,104 @@
+use num_complex::Complex64;
+use numpy::array;
+use numpy::dtype::Dtype;
+use numpy::Array;
+use std::io::Read;
+
+#[test]
+fn test_view() {
+    let a = array![1, 2, 3, 4];
+    let v = a.view();
+
+    assert_eq!(a.shape(), v.shape());
+    assert_eq!(a.strides(), v.strides());
+    assert_eq!(a.size(), v.size());
+
+    // Ensure data is shared (conceptually, though we can't easily check Arc count here without internal access)
+    // But we can check equality
+    assert_eq!(a.to_vec(), v.to_vec());
+}
+
+#[test]
+fn test_astype() {
+    let a = array![1, 2, 3, 4];
+    // converting i32/i64 to f64
+    let b: Array<f64> = a.astype().unwrap();
+
+    assert_eq!(b.dtype(), &Dtype::Float64 { byteorder: None });
+    assert_eq!(b.get(0).unwrap(), &1.0);
+}
+
+#[test]
+fn test_conj() {
+    // Real array conj should be no-op (copy)
+    let a = array![1.0, 2.0];
+    let b = a.conj().unwrap();
+    assert_eq!(a.to_vec(), b.to_vec());
+
+    // Complex array
+    let c1 = Complex64::new(1.0, 2.0);
+    let cArray = Array::from_vec(vec![c1]);
+    let conj = cArray.conj().unwrap();
+
+    let res = conj.get(0).unwrap();
+    assert_eq!(res.re, 1.0);
+    assert_eq!(res.im, -2.0);
+}
+
+#[test]
+fn test_tobytes() {
+    let a = array![1i32, 2i32]; // 4 bytes each = 8 bytes
+    let bytes = a.tobytes().unwrap();
+
+    assert_eq!(bytes.len(), 8);
+    // Little endian check usually
+    // 1 -> 01 00 00 00
+    // 2 -> 02 00 00 00
+    if cfg!(target_endian = "little") {
+        assert_eq!(bytes[0], 1);
+        assert_eq!(bytes[4], 2);
+    }
+}
+
+#[test]
+fn test_tolist() {
+    let a = array![1, 2];
+    // For now, tolist might just return Vec<T> for 1D, or we verify string representation if generic return is hard in Rust
+    let list = a.tolist();
+    // Expectation: some representation we can check.
+    // If tolist returns Vec<T>, then:
+    assert_eq!(list, vec![1, 2]);
+}
+
+#[test]
+fn test_tofile() {
+    let a = array![1, 2, 3];
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let file_path = tmp_dir.path().join("test_array.bin");
+
+    a.tofile(&file_path).unwrap();
+
+    let mut f = std::fs::File::open(file_path).unwrap();
+    let mut buffer = Vec::new();
+    f.read_to_end(&mut buffer).unwrap();
+
+    // 3 * size_of(i32) or i64 depending on default
+    // assuming i64 default for integer literals in array! macro if inferred?
+    // The previous test logic suggests generic T.
+    // `array![1, 2, 3]` usually creates i32 or i64.
+    // Let's assert based on `a.size() * std::mem::size_of::<i32>()` (or i64)
+
+    // In lib.rs: pub type Int = i64;
+    // But macro uses T inference.
+    // Let's use explicit type
+    let a_i32 = Array::from_vec(vec![1i32, 2, 3]);
+    let tmp_dir_2 = tempfile::tempdir().unwrap();
+    let file_path_2 = tmp_dir_2.path().join("test_array_i32.bin");
+    a_i32.tofile(&file_path_2).unwrap();
+
+    let mut f2 = std::fs::File::open(file_path_2).unwrap();
+    let mut buffer2 = Vec::new();
+    f2.read_to_end(&mut buffer2).unwrap();
+
+    assert_eq!(buffer2.len(), 12); // 3 * 4 bytes
+}


### PR DESCRIPTION
Implements 9 new methods for `Array<T>`:
- `astype`: Casting with `num_traits`.
- `view`: Zero-copy view (Arc clone).
- `conj` / `conjugate`: Element-wise conjugate (identity for real, specialized for Complex types via `ElementConj` trait).
- `to_device`: Stub for device movement (currently CPU-only).
- `tobytes`: Raw byte export (unsafe slice reinterpretation).
- `tofile`: File writing.
- `tolist`: 1D/Flat vector export.
- `byteswap`: Stub (not implemented error).

Adds `tests/ndarray_conversion_tests.rs` verifying these methods.

Fixes #414
