### PR TITLE
[Security] Resolve Unmaintained Paste Crate (#424)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1386,7 +1386,7 @@ packages:
 - pypi: ./
   name: pocket-tts
   version: 1.0.3
-  sha256: 5e3b016b5f6f5f8856d4fe1941aca4164d4b9161b5a6a6dc23211731b0406bca
+  sha256: 6aa5ea44ee5307c0955dbf878be84bd85c853e6a8c737d31208f36741134a748
   requires_dist:
   - torch~=2.10.0
   - pydantic~=2.12

--- a/rust-numpy/audit.toml
+++ b/rust-numpy/audit.toml
@@ -1,0 +1,2 @@
+[vulnerabilities]
+ignore = ["RUSTSEC-2024-0436"]


### PR DESCRIPTION
Resolves #424. Adds an `audit.toml` to ignore the unmaintained `paste` crate warning (`RUSTSEC-2024-0436`) until upstream `faer` updates its dependencies.