### PR TITLE
test: Remove authentication hack and improve test error handling

### DIFF
--- a/test_data/comprehensive_test_examples.py
+++ b/test_data/comprehensive_test_examples.py
@@ -660,6 +660,8 @@ def main():
             table = pa.table({"data": arr.flatten()})
             pq.write_table(table, os.path.join(test_dir, f"{name}.parquet"))
         except ImportError:
+            # PyArrow is optional - Parquet export is skipped if not installed
+            # NumPy format is already saved above, so this is a nice-to-have feature
             pass
 
     print(f"Test data saved to {test_dir}")

--- a/test_data/comprehensive_test_examples_fixed.py
+++ b/test_data/comprehensive_test_examples_fixed.py
@@ -651,7 +651,9 @@ def main():
             np.savetxt(
                 os.path.join(test_dir, f"{name}.csv"), arr.flatten(), delimiter=","
             )
-        except Exception:
+        except (ValueError, TypeError) as e:
+            # CSV export may fail for complex dtypes - this is expected for some arrays
+            # NumPy format is already saved above, so this is a nice-to-have feature
             pass
 
     print(f"Test data saved to {test_dir}")

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -72,11 +72,21 @@ def make_my_voice_file():
 
 @pytest.mark.usefixtures("make_my_voice_file")
 def test_get_state_for_audio_prompt():
+    """Test getting voice state from various audio sources.
+
+    Note: This test requires voice cloning capability. If the model was loaded
+    without voice cloning weights, the test will skip the voice cloning examples.
+    """
     from pocket_tts import TTSModel
 
     model = TTSModel.load_model()
-    # hack to make it work without auth
-    model.has_voice_cloning = True
+
+    # Test with predefined voice (always available)
+    voice_state = model.get_state_for_audio_prompt("marius")
+
+    if not model.has_voice_cloning:
+        # Skip voice cloning tests if not available
+        pytest.skip("Voice cloning not available - model loaded without voice cloning weights")
 
     # From HuggingFace URL
     voice_state = model.get_state_for_audio_prompt(


### PR DESCRIPTION
## Summary

Remove the "hack to make it work without auth" comment and replace with proper conditional logic that checks voice cloning availability and skips gracefully when not available. Also improve error handling comments in test data generation files.

## Changes

### Core Test Changes

1. **tests/test_documentation_examples.py** - `test_get_state_for_audio_prompt()`:
   - Removed: `model.has_voice_cloning = True` hack
   - Added: Proper conditional check for `model.has_voice_cloning`
   - Added: `pytest.skip()` with descriptive message when voice cloning unavailable
   - Added: Comprehensive docstring explaining voice cloning requirements
   - Test now works with both predefined voices (always available) and custom voice cloning

2. **test_data/comprehensive_test_examples.py**:
   - Added explanatory comments for ImportError handling when pyarrow is not available
   - Clarified that Parquet export is optional and NumPy format is always saved

3. **test_data/comprehensive_test_examples_fixed.py**:
   - Added specific exception types `(ValueError, TypeError)` for CSV export failures
   - Added explanatory comments for when CSV export fails (complex dtypes)

## Test Plan

- [x] Format: `pixi run ruff format .`
- [x] Lint: `pixi run ruff check .` (pre-existing errors in unrelated files)
- [x] Test: `pixi run pytest tests/test_documentation_examples.py::test_get_state_for_audio_prompt -v` PASSED

## Behavior

- Tests now gracefully skip voice cloning features when unavailable
- No more "hack" comments or manual property overrides
- Better documentation of optional dependency handling

Resolves #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
