### PR TITLE
feat: export window::kaiser function - partial progress on #520

### DIFF
--- a/rust-numpy/src/lib.rs
+++ b/rust-numpy/src/lib.rs
@@ -314,7 +314,7 @@ pub use datetime::{busday_count, busday_offset, datetime_as_string, datetime_dat
 pub use io::{fromfile, fromstring, load, loadtxt, save, savetxt, savez, savez_compressed};
 
 // Window functions
-pub use window::{bartlett, blackman, hamming, hanning};
+pub use window::{bartlett, blackman, hamming, hanning, kaiser};
 // Complex utility functions
 pub use kernel_api::{
     execute_binary, execute_unary, init_kernel_registry, register_binary_kernel,


### PR DESCRIPTION
## Summary\n\nAdded `kaiser` window function to top-level exports in `rust-numpy/src/lib.rs`.\n\n## Changes\n\n**Added kaiser export** (line 317):\n- Exported `kaiser` function from the `window` module\n- This makes the function accessible as `numpy::kaiser`\n\n## Note on Issue #520\n\nThis is **incremental progress** on issue #520 which addresses 214 missing top-level numpy functions.\n\nAccording to analysis:\n- Total numpy functions: 462\n- Present: 248  \n- Missing: 214\n- Namespace mismatch (implemented but not exported): 92 functions\n\nMany functions are already implemented but not exported at the top level. This PR adds one more export, moving toward 100% parity.\n\n## Future Work\n\nTo fully resolve #520, the following approach is recommended:\n1. Export the 92 namespace_mismatch functions (quick wins)\n2. Implement the remaining ~120 truly missing functions\n3. Add comprehensive tests for all functions\n\nThis PR represents step 1 for one function.